### PR TITLE
TMP build: gh-actions: ubuntu-16.04 -> ubuntu-18.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        machine: ['ubuntu-16.04']
+        machine: ['ubuntu-18.04']
         php-version: ['7.0', '7.1', '7.2', '7.3', '7.4']
         run-job: ['env.1', 'env.2']
         experimental: [false]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Symfony console autocomplete
 
-![GitHub Workflow Status](https://img.shields.io/github/workflow/status/bamarni/symfony-console-autocomplete/CI.svg?style=for-the-badge&logo=github)
-[![GitHub issues](https://img.shields.io/github/issues/bamarni/symfony-console-autocomplete.svg?style=for-the-badge&logo=github)](https://github.com/bamarni/symfony-console-autocomplete/issues)
+[![GitHub CI Status](https://img.shields.io/github/workflow/status/bamarni/symfony-console-autocomplete/CI.svg?style=for-the-badge&logo=github)](https://github.com/bamarni/symfony-console-autocomplete/actions/workflows/ci.yml)
+[![GitHub Issues](https://img.shields.io/github/issues/bamarni/symfony-console-autocomplete.svg?style=for-the-badge&logo=github)](https://github.com/bamarni/symfony-console-autocomplete/issues)
 [![Build Status](https://img.shields.io/travis/bamarni/symfony-console-autocomplete.svg?style=for-the-badge&logo=travis)](https://travis-ci.org/bamarni/symfony-console-autocomplete)
 
 [![PHP Version](https://img.shields.io/packagist/php-v/bamarni/symfony-console-autocomplete.svg?style=for-the-badge)](https://github.com/bamarni/symfony-console-autocomplete)


### PR DESCRIPTION
github actions has no ubuntu-16.04 boxes any longer.

showstopper for the build.